### PR TITLE
Disable auto-addition of pip & setuptools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  disable_pip: True
   entry_points:
     - pip = pip:main
 


### PR DESCRIPTION
otherwise you end up with an error about pip not being able to depend on itself.